### PR TITLE
[PR]: Update Ubuntu image in Terraform configuration file

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -115,7 +115,7 @@ resource "google_compute_instance" "server" {
     auto_delete = true
     device_name = "server"
     initialize_params {
-      image = "family/ubuntu-1804-lts"
+      image = "family/ubuntu-2004-lts"
       size  = 10
       type  = "pd-standard"
     }
@@ -155,7 +155,7 @@ resource "google_compute_instance" "client" {
     auto_delete = true
     device_name = "client"
     initialize_params {
-      image = "family/ubuntu-1804-lts"
+      image = "family/ubuntu-2004-lts"
       size  = 10
       type  = "pd-standard"
     }


### PR DESCRIPTION
Description:
This pull request updates the Ubuntu image in the Terraform configuration file to version 20.04. The current image is outdated and not available in the GCP registry, causing errors during infrastructure deployment.

Proposed Changes:
Update the Ubuntu image resource in the Terraform configuration file to version 20.04.
Remove the outdated image reference.
Add the new image reference with the appropriate version and release date.

Steps to Test:
Clone the repository.
Checkout the branch with this pull request.
Run the Terraform configuration file using the command "deploystack install".
Verify that the infrastructure deployment completes successfully without any errors.

Expected Behavior:
After merging this pull request and running the updated Terraform configuration file, the infrastructure deployment should run smoothly on GCP.

Additional Information:
I've singed a contributor agreement. This update ensures that the Terraform configuration file is compatible with the official tutorial and keeps the infrastructure up to date. Thank you for your attention to this matter.

Please review and merge this pull request. Thank you!
